### PR TITLE
Release v3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/react-native-button",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "A button for React apps",
   "main": "Button.js",
   "scripts": {


### PR DESCRIPTION
This proposes releasing the version currently used in production by `metamask-mobile` as `@metamask/react-native-button`@`3.0.0`. (https://github.com/MetaMask/metamask-mobile/blame/9af15b4387bacf8f36122471a873928966f8cee2/package.json#L278)

Note that the package name and imports in `metamask-mobile` are already mismatching the package name , which needs to be fixed downstream.